### PR TITLE
Update phrase links according to updated wit.ai app

### DIFF
--- a/src/utils/parseWitResponse.js
+++ b/src/utils/parseWitResponse.js
@@ -1,4 +1,4 @@
-const MIN_INTENT_COFIDENCE = 0.5;
+const MIN_INTENT_COFIDENCE = 0.8;
 export default (response) => {
     //TODO: This function will be modified depending on the training on Wit.ai service!
     //TODO: Updated Version of Wit.ai will store *Intents* and *Entities* separately in the response!
@@ -20,13 +20,17 @@ export default (response) => {
             parsedResponse = { intent: intent, min: min, max: max };
             break;
         case "group_selection":
-            const group = response.entities.object_in_group.map((obj) => obj.value);
-            parsedResponse = { intent: intent, group: group };
+            if (response.entities.object_in_group) {
+                const group = response.entities.object_in_group.map((obj) => obj.value);
+                parsedResponse = { intent: intent, group: group };
+            }
             break;
         case "comparison":
-            const group1 = response.entities.group_one.map((obj) => obj.value);
-            const group2 = response.entities.group_two.map((obj) => obj.value);
-            parsedResponse = { intent: intent, group1: group1, group2: group2 };
+            if (response.entities.group_one && response.entities.group_two) {
+                const group1 = response.entities.group_one.map((obj) => obj.value);
+                const group2 = response.entities.group_two.map((obj) => obj.value);
+                parsedResponse = { intent: intent, group1: group1, group2: group2 };
+            }
             break;
     }
     return parsedResponse;


### PR DESCRIPTION
Closes #44 
Partly closes #45 

**Summary**

- I extended the same approach to tackle group and comparison intents. 

- For these two intents I'm extracting the entities from wit.ai app

**Range**
![range](https://user-images.githubusercontent.com/25730402/83176630-0993e680-a11e-11ea-8416-42502e8a8cbb.png)

**Group**
![group](https://user-images.githubusercontent.com/25730402/83176887-7d35f380-a11e-11ea-9b4e-c8383616e1d6.png)

**Comparison**
![comparison](https://user-images.githubusercontent.com/25730402/83176925-8a52e280-a11e-11ea-8a8b-9860ca2d8b1c.png)


**Limitations**
- The approach for group & comparison selection will highly depend on `wit.ai` training because I'm relying on extraction of entities (e.g., possible chart features). 

- We can give it a try. If this doesn't work, we can switch to the other mode which we are using for range selections (getting intent from `wit.ai` app and doing entity resolution locally)
