### PR TITLE
fix line chart highlight

### DIFF
--- a/src/utils/addSignalToChartSpec.js
+++ b/src/utils/addSignalToChartSpec.js
@@ -21,7 +21,7 @@ export function addSignalToMark(mark, highlight) {
     if (mark.type === "group") {
         // recursive
         if (mark.marks) {
-            mark.marks.forEach((mark) => addSignalToMark(mark)); // will this generalize to all charts?
+            mark.marks.forEach((mark) => addSignalToMark(mark, highlight)); // will this generalize to all charts?
         }
         return;
     }


### PR DESCRIPTION
I forgot to add a parameter to the recursive function `addSignalToMark`.  Let me know if you run into other issues.